### PR TITLE
test: refactor JSON.DEL test 

### DIFF
--- a/src/test/java/com/redislabs/modules/rejson/ClientTest.java
+++ b/src/test/java/com/redislabs/modules/rejson/ClientTest.java
@@ -191,13 +191,9 @@ public class ClientTest {
     }
 
     @Test
-    public void delException() throws Exception {
-    	Exception ex = assertThrows(JedisDataException.class, () -> {
-    	        client.set( "foobar", new FooBarObject(), Path.ROOT_PATH);
-    	        client.del( "foobar", new Path(".foo[1]")).longValue();
-    	});
-
-    	assertTrue(ex.getMessage().contains("ERR invalid index '[1]' at level 1 in path"));
+    public void delNonExistingPathsAreIgnored() throws Exception {
+	    client.set( "foobar", new FooBarObject(), Path.ROOT_PATH);
+	    client.del( "foobar", new Path(".foo[1]")).longValue();
     }
 
     @Test


### PR DESCRIPTION
The behavior of REDIS when deleting a non-existing path in a JSON document changed from throwing an error to ignoring it. This addresses that change.