### PR TITLE
Spring Integration PR

### DIFF
--- a/src/main/java/com/redislabs/modules/rejson/JReJSON.java
+++ b/src/main/java/com/redislabs/modules/rejson/JReJSON.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
@@ -48,7 +49,13 @@ import redis.clients.jedis.util.SafeEncoder;
  */
 public class JReJSON {
 
-    private static final Gson gson = new Gson();
+    private GsonBuilder gsonBuilder = new GsonBuilder();
+    private Gson gson = gsonBuilder.create();
+
+    public void setGsonBuilder(GsonBuilder gsonBuilder) {
+      this.gsonBuilder = gsonBuilder;
+      this.gson = gsonBuilder.create();
+    }
 
     private enum Command implements ProtocolCommand {
         DEL("JSON.DEL"),
@@ -127,7 +134,7 @@ public class JReJSON {
     public JReJSON(Pool<Jedis> jedis) {
         this.client = jedis;
     }
-    
+
     public JReJSON(Jedis jedis) {
         this.jedis = jedis;
     }
@@ -394,6 +401,8 @@ public class JReJSON {
         }
     }
 
+    private static final Gson staticGson = new Gson();
+
     /**
      * Deletes a path
      * @param conn the Jedis connection
@@ -441,7 +450,7 @@ public class JReJSON {
         String rep = conn.getClient().getBulkReply();
         conn.close();
 
-        return gson.fromJson(rep, Object.class);
+        return staticGson.fromJson(rep, Object.class);
     }
 
     /**
@@ -460,7 +469,7 @@ public class JReJSON {
 
         args.add(SafeEncoder.encode(key));
         args.add(SafeEncoder.encode(getSingleOptionalPath(path).toString()));
-        args.add(SafeEncoder.encode(gson.toJson(object)));
+        args.add(SafeEncoder.encode(staticGson.toJson(object)));
         if (ExistenceModifier.DEFAULT != flag) {
             args.add(flag.getRaw());
         }

--- a/src/main/java/com/redislabs/modules/rejson/JReJSON.java
+++ b/src/main/java/com/redislabs/modules/rejson/JReJSON.java
@@ -100,6 +100,7 @@ public class JReJSON {
     }
 
 	private Pool<Jedis> client;
+	private Jedis jedis;
 
     /**
      * Creates a client to the local machine
@@ -125,6 +126,10 @@ public class JReJSON {
      */
     public JReJSON(Pool<Jedis> jedis) {
         this.client = jedis;
+    }
+    
+    public JReJSON(Jedis jedis) {
+        this.jedis = jedis;
     }
 
     /**
@@ -523,7 +528,7 @@ public class JReJSON {
     }
 
     private Jedis getConnection() {
-        return this.client.getResource();
+        return jedis != null ? jedis : this.client.getResource();
     }
 
     /**

--- a/src/test/java/com/redislabs/modules/rejson/ClientTest.java
+++ b/src/test/java/com/redislabs/modules/rejson/ClientTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.GsonBuilder;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -155,6 +156,16 @@ public class ClientTest {
         // naive set with a path
     	defaultClient.set("null", null, Path.ROOT_PATH);
         assertNull(explicitLocalClient.get("null", String.class, Path.ROOT_PATH));
+    }
+	
+    @Test
+    public void testJedisConstructor() {
+        final JReJSON defaultClient = new JReJSON();
+    	final JReJSON withJedis = new JReJSON(jedis);
+
+        // naive set with a path
+    	defaultClient.set("null", null, Path.ROOT_PATH);
+        assertNull(withJedis.get("null", String.class, Path.ROOT_PATH));
     }
 
     @Test
@@ -567,5 +578,18 @@ public class ClientTest {
     public void testStringLen() {
       client.set( "str", "foo", Path.ROOT_PATH);
       assertEquals(Long.valueOf(3L), client.strLen( "str", Path.ROOT_PATH));
+    }
+	
+    @Test
+    public void testPassingCustomGsonBuilder() {
+      final JReJSON defaultClient = new JReJSON();
+      final JReJSON customizedClient = new JReJSON();
+      final GsonBuilder builder = new GsonBuilder();
+
+      customizedClient.setGsonBuilder(builder);
+
+      // naive set with a path
+      defaultClient.set("null", null, Path.ROOT_PATH);
+      assertNull(customizedClient.get("null", String.class, Path.ROOT_PATH));
     }
 }


### PR DESCRIPTION
This PR allows JRedisJSON to:
* be instantiated used a `Jedis` instance (for envs that manage and serve their own connections, a.k.a. Spring)
* to set the `GsonBuilder` (`Gson` factory) to allow for custom encodings on classes (for example Geo classes in Spring Data such as Point, Distance, etc. https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/geo/package-frame.html)